### PR TITLE
Fix npc limit

### DIFF
--- a/codemp/game/bg_public.h
+++ b/codemp/game/bg_public.h
@@ -301,7 +301,7 @@ typedef struct animation_s {
 extern qboolean			BGPAFtextLoaded;
 extern animation_t		bgHumanoidAnimations[MAX_TOTALANIMATIONS];
 
-#define MAX_ANIM_FILES	16
+#define MAX_ANIM_FILES	128
 #define MAX_ANIM_EVENTS 300
 
 typedef enum


### PR DESCRIPTION
This bug used to crash all clients connected to the server if you spawn more than 16 different npc models on a server.
I increased the limit to 128, which should be more than enough.